### PR TITLE
Fix bin file running on mac

### DIFF
--- a/bin/decomposer
+++ b/bin/decomposer
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 require_once __DIR__ . '/../src/cli.php';


### PR DESCRIPTION
> exec: Failed to execute process '/Users/me/.composer/vendor/bin/decomposer': The file specified the interpreter '/usr/bin/php', which is not an executable command.

Using same what composer or symfony uses: https://github.com/composer/composer/blob/685add70ec84d18075a202686288304db0d6d265/bin/composer#L1 